### PR TITLE
Fix theme variables under lightning-css

### DIFF
--- a/app/components/header.gts
+++ b/app/components/header.gts
@@ -6,11 +6,29 @@ function isDark() {
   return colorScheme.isDark;
 }
 
+/*
+ * ember-primitives writes `style="color-scheme: dark"` on <html> and
+ * round-trips it to localStorage, but we can't select on inline-style
+ * declarations from CSS. lightning-css (Vite's CSS pipeline) also
+ * ships an inconsistent `light-dark()` implementation, so anything
+ * built on top of it ends up with empty variable values.
+ *
+ * Mirror the live theme onto a `data-theme` attribute instead — it's
+ * a plain selector target every CSS engine handles, and the helper is
+ * called from the template so it re-runs whenever `colorScheme.current`
+ * (a tracked value) changes.
+ */
+function syncDataTheme() {
+  const root = document.documentElement;
+  root.dataset['theme'] = colorScheme.isDark ? 'dark' : 'light';
+}
+
 function toggle() {
   colorScheme.update(colorScheme.isDark ? 'light' : 'dark');
 }
 
 export const Header = <template>
+  {{ (syncDataTheme) }}
   <header>
     <span>
       <LinkTo @route="application" class="home-link">

--- a/app/components/header.gts
+++ b/app/components/header.gts
@@ -28,7 +28,7 @@ function toggle() {
 }
 
 export const Header = <template>
-  {{ (syncDataTheme) }}
+  {{(syncDataTheme)}}
   <header>
     <span>
       <LinkTo @route="application" class="home-link">

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1,36 +1,30 @@
+/*
+ * Theme variables — light defaults, with a `[data-theme="dark"]`
+ * override for the explicit dark state. The `data-theme` attribute is
+ * mirrored onto <html> by `syncDataTheme()` in `header.gts`, which
+ * runs every time `colorScheme.current` changes.
+ *
+ * lightning-css (Vite's CSS pipeline) doesn't reliably resolve the
+ * `light-dark()` function, so we deliberately don't rely on it — every
+ * variable here is a literal value, and switching themes just swaps
+ * which selector is winning.
+ */
 :root {
-  /*
-   * Theme variables resolve via the CSS `light-dark()` function, which
-   * picks the value matching the active `color-scheme`. ember-primitives'
-   * `colorScheme.update()` (and its `sync()` boot hook) writes
-   * `color-scheme: dark` or `color-scheme: light` onto <html>, so changing
-   * the theme just retargets `light-dark()` — no JS-driven CSS attribute
-   * needed.
-   */
-  color-scheme: light dark;
+  color-scheme: light;
 
-  --bg: light-dark(#fff, #151515);
-  --fg: light-dark(#1a1a1a, #efefef);
-  --muted: light-dark(#6a6a6a, #9a9a9a);
-  --border: light-dark(#e2e2e6, #2a2a2e);
-  --row-alt: light-dark(#fafafa, #1b1b1d);
-  --row-hover: light-dark(#f1f4ff, #232331);
-  --control-bg: light-dark(#f5f5f7, #1f1f22);
+  --bg: #fff;
+  --fg: #1a1a1a;
+  --muted: #6a6a6a;
+  --border: #e2e2e6;
+  --row-alt: #fafafa;
+  --row-hover: #f1f4ff;
+  --control-bg: #f5f5f7;
 
-  --accent: light-dark(#6464ff, #8a8aff);
-  --accent-soft: light-dark(
-    rgba(100, 100, 255, 0.15),
-    rgba(138, 138, 255, 0.18)
-  );
+  --accent: #6464ff;
+  --accent-soft: rgba(100, 100, 255, 0.15);
 
-  --shadow-sm: light-dark(
-    0 1px 2px rgba(0, 0, 0, 0.05),
-    0 1px 2px rgba(0, 0, 0, 0.4)
-  );
-  --shadow-md: light-dark(
-    0 6px 18px rgba(0, 0, 0, 0.08),
-    0 6px 18px rgba(0, 0, 0, 0.5)
-  );
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 6px 18px rgba(0, 0, 0, 0.08);
 
   --radius: 8px;
   --radius-sm: 4px;
@@ -38,6 +32,50 @@
   --font-stack:
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
     Arial, sans-serif;
+}
+
+:root[data-theme='dark'] {
+  color-scheme: dark;
+
+  --bg: #151515;
+  --fg: #efefef;
+  --muted: #9a9a9a;
+  --border: #2a2a2e;
+  --row-alt: #1b1b1d;
+  --row-hover: #232331;
+  --control-bg: #1f1f22;
+
+  --accent: #8a8aff;
+  --accent-soft: rgba(138, 138, 255, 0.18);
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 6px 18px rgba(0, 0, 0, 0.5);
+}
+
+/*
+ * First paint, before `syncDataTheme()` has run: honour the OS
+ * preference so users on a dark system don't flash a white page.
+ * Once the JS runs and sets `data-theme`, that explicit choice wins
+ * over this media query.
+ */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    color-scheme: dark;
+
+    --bg: #151515;
+    --fg: #efefef;
+    --muted: #9a9a9a;
+    --border: #2a2a2e;
+    --row-alt: #1b1b1d;
+    --row-hover: #232331;
+    --control-bg: #1f1f22;
+
+    --accent: #8a8aff;
+    --accent-soft: rgba(138, 138, 255, 0.18);
+
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --shadow-md: 0 6px 18px rgba(0, 0, 0, 0.5);
+  }
 }
 
 * {


### PR DESCRIPTION
## Summary

The theme variables relied on the CSS `light-dark()` function (`--bg: light-dark(#fff, #151515)` etc.). lightning-css — the CSS pipeline Vite uses — doesn't reliably resolve `light-dark()`, so at runtime those variables came through as empty strings. Anything reading `var(--bg)` then fell back to its inherit / initial color, which is why theme switching looked flaky.

Switch back to the well-supported `data-theme` attribute pattern:

- `:root` declares literal _light_ values.
- `:root[data-theme='dark']` overrides with literal dark values.
- `@media (prefers-color-scheme: dark)` handles the brief first-paint window before JS runs (so OS-dark users don't flash white).

`Header` now calls a tiny `syncDataTheme()` helper from its template, which mirrors `colorScheme.isDark` onto `<html data-theme="…">`. Since `colorScheme.current` is tracked, the helper re-runs automatically whenever the theme flips — no extra effect / observer wiring needed.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm vitest run` clean
- [x] Smoke in headless Chrome: initial `--bg = #fff`, toggle → `--bg = #151515`, toggle back → `#fff`, reload preserves the last choice.
- [x] OS-dark first paint: `:root:not([data-theme])` + media query keeps the page dark before the JS sync runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)