### PR TITLE
Fix sorting of date columns

### DIFF
--- a/app/utils/sort-rows.ts
+++ b/app/utils/sort-rows.ts
@@ -4,15 +4,35 @@ import type { SortItem } from '@universal-ember/table/plugins/data-sorting';
  * Compare two row objects according to the active multi-key sort spec.
  *
  * For each `SortItem`:
- *   - If both cells parse as numbers, compare numerically.
+ *   - If both cells look like dates, compare chronologically.
+ *   - Else if both cells parse as numbers, compare numerically.
  *   - Otherwise fall back to a locale-aware string compare.
  * The first non-zero comparison wins; descending direction inverts it.
+ *
+ * Dates must be checked before numbers: `parseFloat('2026-01-15')`
+ * happily returns `2026`, which made every date within the same year
+ * compare as equal (and `1/15/2026` compare as `1`).
  *
  * `SortDirection` is matched by its string value to keep this module
  * dependency-free of the table runtime — handy for unit tests and for
  * keeping this small primitive importable from anywhere.
  */
 const DESCENDING = 'descending';
+
+/**
+ * Three date components with a 4-digit year leading (`2026-01-15`,
+ * `2026/1/5`) or trailing (`1/15/2026`), optionally followed by a time.
+ * `Date.parse` alone is far too permissive (`'1.5.3'` parses as
+ * Jan 5 2003), so only strings matching this shape are handed to it.
+ */
+const DATE_LIKE =
+  /^(?:\d{4}[-/]\d{1,2}[-/]\d{1,2}|\d{1,2}[-/]\d{1,2}[-/]\d{4})(?:[T ].+)?$/;
+
+function asTimestamp(value: string): number | undefined {
+  if (!DATE_LIKE.test(value)) return undefined;
+  const timestamp = Date.parse(value);
+  return isNaN(timestamp) ? undefined : timestamp;
+}
 
 export function compareRows<T extends Record<string, string>>(
   sorts: ReadonlyArray<SortItem<T>>
@@ -21,14 +41,21 @@ export function compareRows<T extends Record<string, string>>(
     for (const { property, direction } of sorts) {
       const av = a[property as keyof T] ?? '';
       const bv = b[property as keyof T] ?? '';
-      const af = parseFloat(av);
-      const bf = parseFloat(bv);
+      const ad = asTimestamp(av);
+      const bd = asTimestamp(bv);
 
       let result: number;
-      if (!isNaN(af) && !isNaN(bf)) {
-        result = af - bf;
+      if (ad !== undefined && bd !== undefined) {
+        result = ad - bd;
       } else {
-        result = av.localeCompare(bv);
+        const af = parseFloat(av);
+        const bf = parseFloat(bv);
+
+        if (!isNaN(af) && !isNaN(bf)) {
+          result = af - bf;
+        } else {
+          result = av.localeCompare(bv);
+        }
       }
 
       if (result !== 0) {
@@ -98,6 +125,105 @@ if (import.meta.vitest) {
       const rows = [{ name: 'a' }, { name: 'b', score: '5' }] as Row[];
       const sorted = [...rows].sort(compareRows([asc('score')]));
       expect(sorted[0]?.name).toBe('a');
+    });
+
+    it('sorts numbers with unit suffixes numerically', () => {
+      const rows: Row[] = [
+        { name: 'a', score: '10.2s' },
+        { name: 'b', score: '2.1s' },
+        { name: 'c', score: '7s' },
+      ];
+      const sorted = [...rows].sort(compareRows([asc('score')]));
+      expect(sorted.map((r) => r.score)).toEqual(['2.1s', '7s', '10.2s']);
+    });
+  });
+
+  describe('compareRows: dates', () => {
+    type DateRow = { edate: string };
+    const byEdate = (direction: string): SortItem<DateRow>[] => [
+      { property: 'edate', direction: direction as Direction },
+    ];
+
+    it('sorts ISO dates within the same year chronologically', () => {
+      // Regression: parseFloat('2026-03-02') === 2026, so all same-year
+      // dates used to compare as equal and never sorted.
+      const rows: DateRow[] = [
+        { edate: '2026-03-02' },
+        { edate: '2026-11-30' },
+        { edate: '2026-01-15' },
+      ];
+      const sorted = [...rows].sort(compareRows(byEdate('ascending')));
+      expect(sorted.map((r) => r.edate)).toEqual([
+        '2026-01-15',
+        '2026-03-02',
+        '2026-11-30',
+      ]);
+    });
+
+    it('sorts ISO dates descending', () => {
+      const rows: DateRow[] = [
+        { edate: '2026-01-15' },
+        { edate: '2026-11-30' },
+        { edate: '2026-03-02' },
+      ];
+      const sorted = [...rows].sort(compareRows(byEdate('descending')));
+      expect(sorted.map((r) => r.edate)).toEqual([
+        '2026-11-30',
+        '2026-03-02',
+        '2026-01-15',
+      ]);
+    });
+
+    it('sorts month-first slash dates chronologically, not by leading number', () => {
+      // parseFloat('12/5/2024') === 12, which sorted these by month.
+      const rows: DateRow[] = [
+        { edate: '12/5/2024' },
+        { edate: '1/15/2026' },
+        { edate: '3/1/2024' },
+      ];
+      const sorted = [...rows].sort(compareRows(byEdate('ascending')));
+      expect(sorted.map((r) => r.edate)).toEqual([
+        '3/1/2024',
+        '12/5/2024',
+        '1/15/2026',
+      ]);
+    });
+
+    it('sorts dates with time components', () => {
+      const rows: DateRow[] = [
+        { edate: '2026-01-15 10:30' },
+        { edate: '2026-01-15 09:15' },
+        { edate: '2026-01-14 23:59' },
+      ];
+      const sorted = [...rows].sort(compareRows(byEdate('ascending')));
+      expect(sorted.map((r) => r.edate)).toEqual([
+        '2026-01-14 23:59',
+        '2026-01-15 09:15',
+        '2026-01-15 10:30',
+      ]);
+    });
+
+    it('sorts blank cells before dates, ascending', () => {
+      const rows: DateRow[] = [
+        { edate: '2026-01-15' },
+        { edate: '' },
+        { edate: '2026-01-02' },
+      ];
+      const sorted = [...rows].sort(compareRows(byEdate('ascending')));
+      expect(sorted.map((r) => r.edate)).toEqual([
+        '',
+        '2026-01-02',
+        '2026-01-15',
+      ]);
+    });
+
+    it('does not treat version-like strings as dates', () => {
+      // Date.parse('1.5.3') succeeds (!), so the date path must not
+      // accept dot-separated values. Comparing as dates would put
+      // '12.1.2' (Dec 1 2002) before '1.5.3' (Jan 5 2003).
+      const rows: DateRow[] = [{ edate: '12.1.2' }, { edate: '1.5.3' }];
+      const sorted = [...rows].sort(compareRows(byEdate('ascending')));
+      expect(sorted.map((r) => r.edate)).toEqual(['1.5.3', '12.1.2']);
     });
   });
 }


### PR DESCRIPTION
## The bug

Sorting a date column (e.g. an `edate` column) didn't work. `compareRows` tries a numeric compare first via `parseFloat`, and `parseFloat('2026-01-15')` returns `2026` — so every date within the same year compared as **equal** and the column never re-ordered. Month-first dates were actively wrong rather than inert: `parseFloat('12/5/2024')` returns `12`, so those sorted by month regardless of year.

## The fix

Compare date-like cells chronologically **before** the numeric fallback (order matters, since `parseFloat` happily swallows the leading year/month of a date string).

Date detection is a shape regex — three components with a 4-digit year leading (`2026-01-15`, `2026/1/5`) or trailing (`1/15/2026`), `-` or `/` separators, optional time suffix — validated by `Date.parse`. The regex gate is load-bearing: `Date.parse` alone is far too permissive (`Date.parse('1.5.3')` succeeds and returns Jan 5 2003).

Non-date behavior is unchanged:
- unit-suffixed numbers (`2.1s`, `10.2s`) still sort numerically via `parseFloat`
- blank cells still sort first ascending
- dot-separated version-like strings never enter the date path

## Tests

Added 7 in-source vitest cases: same-year ISO regression, descending, month-first slash dates, date+time, blanks mixed with dates, version-string guard, and a unit-suffix regression guard for the existing numeric path. `pnpm test:vitest`: 23 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)